### PR TITLE
Don't limit mobs spawned from a mobspawner

### DIFF
--- a/src/me/ryanhamshire/PopulationDensity/EntityEventHandler.java
+++ b/src/me/ryanhamshire/PopulationDensity/EntityEventHandler.java
@@ -219,8 +219,8 @@ public class EntityEventHandler implements Listener
 		    }
 		}
 	    
-	    //speed limit on monster grinder spawn rates
-	    if(reason != SpawnReason.SPAWNER_EGG && entity instanceof Monster)
+	    //speed limit on monster grinder spawn rates - only affects grinders that rely on naturally-spawning monsters.
+	    if(reason != SpawnReason.SPAWNER_EGG && reason != SpawnReason.SPAWNER && entity instanceof Monster)
 	    {
 	        Chunk chunk = entity.getLocation().getChunk();
 	        int monstersNearby = 0;


### PR DESCRIPTION
Mobs spawned from a mobspawner do not affect the limits of naturally-spawning mobs, and as such, do not contribute to the starvation of the global monster spawning limit. If it is desired to also limit mob-spawned mobs, this should at least not be included on the same config node.